### PR TITLE
Add newline for emitting multiple JSON records to create valid ndjson files

### DIFF
--- a/cmd/webanalyze/main.go
+++ b/cmd/webanalyze/main.go
@@ -138,6 +138,7 @@ func main() {
 				log.Printf("cannot marshal output: %v\n", err)
 			}
 
+			b = append(b, '\n')
 			os.Stdout.Write(b)
 		}
 	}


### PR DESCRIPTION
Just doing `os.Stdout.Write(b)` won't emit a newline and to create sequential JSON records (when scanning multiple hosts at one time) that are valid ndjson requires a newline to be at the end. This tiny commit just adds a newline to the byte array before the `Write`.