### PR TITLE
Added flag to avoid printing header

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ If you want to build for yourself:
             output format (stdout|csv|json) (default "stdout")
       -search
             searches all urls with same base domain (i.e. example.com and sub.example.com) (default true)
+      -silent
+    	    avoid printing header (default false)
       -update
             update apps file
       -worker int

--- a/cmd/webanalyze/main.go
+++ b/cmd/webanalyze/main.go
@@ -25,6 +25,7 @@ var (
 	hosts           string
 	crawlCount      int
 	searchSubdomain bool
+	silent		bool
 )
 
 func init() {
@@ -36,6 +37,7 @@ func init() {
 	flag.StringVar(&hosts, "hosts", "", "filename with hosts, one host per line.")
 	flag.IntVar(&crawlCount, "crawl", 0, "links to follow from the root page (default 0)")
 	flag.BoolVar(&searchSubdomain, "search", true, "searches all urls with same base domain (i.e. example.com and sub.example.com)")
+	flag.BoolVar(&silent, "silent", false, "avoid printing header (default false)")
 }
 
 func main() {
@@ -95,7 +97,9 @@ func main() {
 		log.Fatalf("initialization failed: %v", err)
 	}
 
-	printHeader()
+	if !silent {
+		printHeader()
+	}
 
 	for i := 0; i < workers; i++ {
 		wg.Add(1)


### PR DESCRIPTION
When incoorporating `Webanalyzer` into scripts to enumerate several items of a target the non-optional header printing was inconvinient. Hence I've created the `-silent` `bool` flag to allow for disabling the header printing.

Compile + test with and without `-silent` option:

```
~/dev/webanalyze (optional_header) $ go build -o webanalyze cmd/webanalyze/main.go 
root@kali:~/dev/webanalyze (optional_header) $ ./webanalyze 
Usage of ./webanalyze:
  -apps string
    	app definition file. (default "apps.json")
  -crawl int
    	links to follow from the root page (default 0)
  -host string
    	single host to test
  -hosts string
    	filename with hosts, one host per line.
  -output string
    	output format (stdout|csv|json) (default "stdout")
  -search
    	searches all urls with same base domain (i.e. example.com and sub.example.com) (default true)
  -silent
    	avoid printing header (default false)
  -update
    	update apps file
  -worker int
    	number of worker (default 4)
~/dev/webanalyze (optional_header) $ ./webanalyze -update
2020/04/10 03:46:52 app definition file updated from  https://raw.githubusercontent.com/AliasIO/Wappalyzer/master/src/apps.json
~/dev/webanalyze (optional_header) $ ./webanalyze -host robinverton.de -crawl 1
 :: webanalyze        : v1.0
 :: workers           : 4
 :: apps              : apps.json
 :: crawl count       : 1
 :: search subdomains : true

http://robinverton.de (0.4s):
    Netlify,  (PaaS, CDN)
~/dev/webanalyze (optional_header) $ ./webanalyze -host robinverton.de -crawl 1 -silent
http://robinverton.de (0.4s):
    Netlify,  (PaaS, CDN)
```