### PR TITLE
Use io.Reader interface instead of os.File for apps data

### DIFF
--- a/cmd/webanalyze/main.go
+++ b/cmd/webanalyze/main.go
@@ -93,7 +93,12 @@ func main() {
 	var wg sync.WaitGroup
 	hosts := make(chan string)
 
-	if wa, err = webanalyze.NewWebAnalyzer(apps); err != nil {
+	appsFile, err := os.Open(apps)
+	if err != nil {
+		log.Fatalf("error: can not open apps file %s: %s", apps, err)
+	}
+	defer appsFile.Close()
+	if wa, err = webanalyze.NewWebAnalyzer(appsFile); err != nil {
 		log.Fatalf("initialization failed: %v", err)
 	}
 

--- a/wappalyze.go
+++ b/wappalyze.go
@@ -120,16 +120,10 @@ func DownloadFile(from, to string) error {
 	return err
 }
 
-// load apps from file
-func (wa *WebAnalyzer) loadApps(filename string) error {
-	f, err := os.Open(filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	dec := json.NewDecoder(f)
-	if err = dec.Decode(&wa.appDefs); err != nil {
+// load apps from io.Reader
+func (wa *WebAnalyzer) loadApps(r io.Reader) error {
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&wa.appDefs); err != nil {
 		return err
 	}
 

--- a/webanalyze.go
+++ b/webanalyze.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -49,13 +50,13 @@ func (m *Match) updateVersion(version string) {
 	}
 }
 
-// NewWebAnalyzer initializes webanalyzer by passing a filename of the
+// NewWebAnalyzer initializes webanalyzer by passing a reader of the
 // app definition and an schedulerChan, which allows the scanner to
 // add scan jobs on its own
-func NewWebAnalyzer(appsFile string) (*WebAnalyzer, error) {
+func NewWebAnalyzer(apps io.Reader) (*WebAnalyzer, error) {
 	wa := new(WebAnalyzer)
 
-	if err := wa.loadApps(appsFile); err != nil {
+	if err := wa.loadApps(apps); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
First of all, thanks for this awesome package!

I'm  trying to use `webanalyze` as a library but using `apps.json` file is not suitable in my use case, so I'd like to `io.Reader` interface instead. However, `webanalyze` relies on `os.File` implementation.

This pull request makes it rely on `io.Reader` instead of `os.File`.