### PR TITLE
Minor update to readme instruction regarding building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Precompiled releases can be downloaded directly [here](https://github.com/rverto
 
 If you want to build for yourself:
 
-    $ go get -u github.com/rverton/webanalyze/...
+    $ go get -v -u github.com/rverton/webanalyze/cmd/webanalyze
     $ webanalyze -update # loads new apps.json file from wappalyzer project
     $ webanalyze -h
     Usage of webanalyze:


### PR DESCRIPTION
Signed-off-by: Casper Guldbech Nielsen <whopsec@protonmail.com>

The building from source didn't include the full path (e.g. `github.com/rverton/webanalyze/cmd/webanalyze`) which I've added to avoid confusion. 
I've also included the -u flag to enable updates from the network.

Cheers and once again thanks for creating `Webanalyzer`!

/Casper