### PR TITLE
Use %w verb

### DIFF
--- a/webanalyze.go
+++ b/webanalyze.go
@@ -210,7 +210,7 @@ func (wa *WebAnalyzer) process(job *Job, appDefs *AppsDefinition) ([]Match, []st
 	} else {
 		resp, err := fetchHost(job.URL, wa.client)
 		if err != nil {
-			return nil, links, fmt.Errorf("Failed to retrieve: %v", err)
+			return nil, links, fmt.Errorf("Failed to retrieve: %w", err)
 		}
 
 		defer resp.Body.Close()


### PR DESCRIPTION
Use `%w` verb so the error returned by `fmt.Errorf` will have an `Unwrap` method.