### PR TITLE
bugfix: wappalizer perform lowercases match

### DIFF
--- a/wappalyze.go
+++ b/wappalyze.go
@@ -178,7 +178,7 @@ func compileNamedRegexes(from map[string]string) []AppRegexp {
 		// Filter out webapplyzer attributes from regular expression
 		splitted := strings.Split(value, "\\;")
 
-		r, err := regexp.Compile(splitted[0])
+		r, err := regexp.Compile("(?i)" + splitted[0])
 		if err != nil {
 			continue
 		}
@@ -202,7 +202,7 @@ func compileRegexes(s StringArray) []AppRegexp {
 		// Split version detection
 		splitted := strings.Split(regexString, "\\;")
 
-		regex, err := regexp.Compile(splitted[0])
+		regex, err := regexp.Compile("(?i)" + splitted[0])
 		if err != nil {
 			// ignore failed compiling for now
 			// log.Printf("warning: compiling regexp for failed: %v", regexString, err)


### PR DESCRIPTION
I'm pretty sure that wapplyzer perform lowercases matchs.
Note these web links:

   "<link [^>]*?href=\"?[a-z]*?:?//cdn\\.statically\\.io/"
   "<small>SquirrelMail version ([.\\d]+)[^<]*<br \\;version:\\1"
   "<input type=\"hidden\" name=\"shopid\""

HTML specify tags are case insensitive.

Another example for detecting PHP:

   "X-Powered-By": "^php/?([\\d.]+)?\\;version:\\1"

In facts, php retruns this header:

    x-powered-by: PHP/7.3.27

So the regex match only in case insensitive.

Note this line in the wappalyzer sources:
   https://github.com/AliasIO/wappalyzer/blob/557bed87113c8f7073a733d85bb9c7cdb67132c3/src/drivers/webextension/js/driver.js#L49

It seems this bloc of code compiles regex, it uses the flag 'i'. (if someone understand javascript, it could be validate this ?)