### PR TITLE
Bugfix: doesn't returns all links

### DIFF
--- a/webanalyze.go
+++ b/webanalyze.go
@@ -168,7 +168,7 @@ func resolveLink(base *url.URL, val string, searchSubdomain bool) string {
 		return ""
 	}
 
-	if searchSubdomain && !isSubdomain(base, u) {
+	if searchSubdomain && !isSubdomain(base, urlResolved) {
 		return ""
 	}
 


### PR DESCRIPTION
When searchSubdomain option is set, the program compare the new to base
in order to determine if it is a sub domain.

In the case we anamlyase a web site https://www.ozon.io/, we activate
searchSubdomain and we encounter a relitive link /offers, we have this
case:

   base = url.Parse("https://www.ozon.io/")
	ref = url.Parse("/offers")

We compare the subdomains of base and ref, and they are always different
because "ref" is not a absolute links. So https://www.ozon.io/offers is
not returned as link, but it should be returned.

This path propose compare the result of base.ResolveReference(ref) in place
of ref. this solve the problem because base.ResolveReference set the right
hostname in the result.