### PR TITLE
new technologies url

### DIFF
--- a/wappalyze.go
+++ b/wappalyze.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-const WappazlyerRoot = "https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src"
+const WappazlyerRoot = "https://raw.githubusercontent.com/enthec/webappanalyzer/main/src"
 
 // StringArray type is a wrapper for []string for use in unmarshalling the technologies.json
 type StringArray []string


### PR DESCRIPTION
After wappalyzer went dark, we decided to take the last copy of technologies and maintain it ourselves using our resources, we will be listening for issues and fixing them aswell as this kind of service is quite useful to us.