### PR TITLE
Piping the tool output to other tools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # webanalyze
 
-This is a port of [Wappalyzer](https://github.com/AliasIO/Wappalyzer) in Go. This tool is designed to be performant and allows to test huge lists of hosts.
+This is a fork  of [Wappalyzer](https://github.com/rverton/webanalyze/releases) in Go. This tool is designed to be performant and allows to test huge lists of hosts.
+
+👾 Added piping capabilities where the output is a one line csv for each host
 
 ## Installation and usage
 
@@ -11,8 +13,9 @@ Precompiled releases can be downloaded directly [here](https://github.com/rverto
 ### Build
 If you want to build for yourself:
 
-    $ go install -v github.com/rverton/webanalyze/cmd/webanalyze@latest
+    $ go install -v github.com/TheeEclipse/webanalyze/cmd/webanalyze@latest
     $ webanalyze -update # loads new technologies.json file from wappalyzer project
+    Or rather just wget the technologies file
     $ webanalyze -h
     Usage of webanalyze:
       -apps string
@@ -37,52 +40,30 @@ If you want to build for yourself:
 
 The `-update` flags downloads a current version of `technologies.json` from the [wappalyzer repository](https://github.com/AliasIO/Wappalyzer) to the current folder.
 
-### Docker
-
-```bash
-# Clone the repo
-git clone https://github.com/rverton/webanalyze.git
-# Build the container
-docker build -t webanalyze:latest webanalyze
-# Run the container
-docker run -it webanalyze:latest -h
-```
-
-## Development / Usage as a lib
 
 See `cmd/webanalyze/main.go` for an example on how to use this as a library.
 
 ## Example
 
-    $ ./webanalyze -host robinverton.de -crawl 1
-     :: webanalyze        : v1.0
-     :: workers           : 4
-     :: apps              : technologies.json
-     :: crawl count       : 1
-     :: search subdomains : true
+    $ root@Normal-Use-Instance:~# webanalyze -host robinverton.de -crawl 1 -silent
+```http://robinverton.de (0.5s): React,  (JavaScript frameworks) HSTS,  (Security) Netlify,  (PaaS, CDN)```
 
-    https://robinverton.de/hire/ (0.5s):
-        Highlight.js,  (Miscellaneous)
-        Netlify,  (Web Servers, CDN)
-        Google Font API,  (Font Scripts)
-    http://robinverton.de (0.8s):
-        Highlight.js,  (Miscellaneous)
-        Netlify,  (Web Servers, CDN)
-        Hugo, 0.42.1 (Static Site Generator)
-        Google Font API,  (Font Scripts)
+    $ root@Normal-Use-Instance:~# webanalyze -host robinverton.de -crawl 1 -silent | anew 2.txt
+```
+http://robinverton.de (0.5s): HSTS,  (Security) Netlify,  (PaaS, CDN) React,  (JavaScript frameworks)
+root@Normal-Use-Instance:~#
+```
 
-    $ ./webanalyze -host robinverton.de -crawl 1 -output csv
-     :: webanalyze        : v1.0
-     :: workers           : 4
-     :: apps              : technologies.json
-     :: crawl count       : 1
-     :: search subdomains : true
+    $ root@Normal-Use-Instance:~# webanalyze -host robinverton.de -crawl 1
+```
+ :: webanalyze        : v0.3.9
+ :: workers           : 4
+ :: technologies      : technologies.json
+ :: crawl count       : 1
+ :: search subdomains : true
+ :: follow redirects  : false
 
-    Host,Category,App,Version
-    https://robinverton.de/hire/,Miscellaneous,Highlight.js,
-    https://robinverton.de/hire/,Font Scripts,Google Font API,
-    https://robinverton.de/hire/,"Web Servers,CDN",Netlify,
-    http://robinverton.de,"Web Servers,CDN",Netlify,
-    http://robinverton.de,Static Site Generator,Hugo,0.42.1
-    http://robinverton.de,Miscellaneous,Highlight.js,
-    http://robinverton.de,Font Scripts,Google Font API,
+http://robinverton.de (0.5s): React,  (JavaScript frameworks) HSTS,  (Security) Netlify,  (PaaS, CDN)
+root@Normal-Use-Instance:~#
+```
+

--- a/cmd/webanalyze/main.go
+++ b/cmd/webanalyze/main.go
@@ -170,7 +170,7 @@ func output(result webanalyze.Result, wa *webanalyze.WebAnalyzer, outWriter *csv
 
 	switch outputMethod {
 	case "stdout":
-		fmt.Printf("%v (%.1fs):\n", result.Host, result.Duration.Seconds())
+		fmt.Printf("%v (%.1fs): ", result.Host, result.Duration.Seconds())
 		for _, a := range result.Matches {
 
 			var categories []string
@@ -179,12 +179,12 @@ func output(result webanalyze.Result, wa *webanalyze.WebAnalyzer, outWriter *csv
 				categories = append(categories, wa.CategoryById(cid))
 			}
 
-			fmt.Printf("    %v, %v (%v)\n", a.AppName, a.Version, strings.Join(categories, ", "))
+			fmt.Printf("%v, %v (%v) ", a.AppName, a.Version, strings.Join(categories, ", "))
 		}
 		if len(result.Matches) <= 0 {
-			fmt.Printf("    <no results>\n")
+			fmt.Printf("<no results>")
 		}
-
+		fmt.Printf("\n")
 	case "csv":
 		for _, m := range result.Matches {
 			outWriter.Write(

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/PuerkitoBio/goquery v1.6.0
 	github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89
-	golang.org/x/net v0.7.0 // indirect
+	github.com/rverton/webanalyze v0.3.9
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rverton/webanalyze
+module github.com/TheeEclipse/webanalyze
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/TheeEclipse/techdetect
+module  github.com/TheeEclipse/webanalyze
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/TheeEclipse/webanalyze
+module github.com/TheeEclipse/techdetect
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5z
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89 h1:2pkAuIM8OF1fy4ToFpMnI4oE+VeUNRbGrpSLKshK0oQ=
 github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89/go.mod h1:/09nEjna1UMoasyyQDhOrIn8hi2v2kiJglPWed1idck=
+github.com/rverton/webanalyze v0.3.9 h1:7e72nVo8rb/lgn4x0Yo+X6vtmeeEgJw/aAwK/TUCogk=
+github.com/rverton/webanalyze v0.3.9/go.mod h1:GcF5GORMQmysI8vdGyJlc50exWMrfKMunRcZP0dOz7w=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=


### PR DESCRIPTION
The code at:
``` case "stdout":```
		
made it unable tp pipe the tool results to other go tools like anew or notify by project discovery because of the new line parameters.
I changed that and can now pipe the results by outputing as csv but as new lines for each host.
Example pipe: 
```/root/go/bin/webanalyze -crawl 4 -silent -redirect -hosts /root/urls.txt | /root/go/bin/anew /root/TechDetect.txt```